### PR TITLE
store details of snapshot diff failures when snapshot runs in silent mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # cypress-image-snapshot
 
+## 4.2.0
+
+- Adding support to access details of snapshot diff failures even when using `failOnSnapshotDiff=false`. Details of diff failures can now be accessed from an object stored in `Cypress.env("snapshotDiffs")`, diff details are keyed by the name of the snapshot image.
+
+## 4.1.0
+
+- Using custom version of [jest-image-snapshot](https://github.com/thecapdan/jest-image-snapshot) and adding support for preserving newly created snapshots on failure.
+
 ## 4.0.1
+
 ### Patch Changes
-
-
 
 - [`17f7927`](https://github.com/jaredpalmer/cypress-image-snapshot/commit/17f7927384bfdbd6cbb65d344c8337d32926b691) Thanks [@jaredpalmer](https://github.com/jaredpalmer)! - When using native retries that come in Cypress v5+ real image failures are marked as passed on the retries because cypress names the snapshots as 'filename (attempt X).png (and there is no configuration option to change this). The fix just removes the ' (attempt X)' suffix from the filename.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thecapdan/cypress-image-snapshot",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "description": "Cypress bindings for jest-image-snapshot.",
   "repository": "https://github.com/thecapdan/cypress-image-snapshot",
   "author": "Jack Cross <jack@palmer.net>",

--- a/src/command.js
+++ b/src/command.js
@@ -57,6 +57,7 @@ export function matchImageSnapshotCommand(defaultOptions) {
             if (failOnSnapshotDiff) {
               throw new Error(message);
             } else {
+              registerSnapshotDiff(name, message);
               Cypress.log({ message });
             }
           }
@@ -78,4 +79,10 @@ export function addMatchImageSnapshotCommand(
     },
     matchImageSnapshotCommand(options)
   );
+}
+
+function registerSnapshotDiff(name, message) {
+  let snapshotDiffs = Cypress.env('snapshotDiffs') || {};
+  snapshotDiffs[name] = message;
+  Cypress.env('snapshotDiffs', snapshotDiffs);
 }


### PR DESCRIPTION
Intended use:

When running the tests in silent mode (using flag `failOnSnapshotDiff=false`), we can then handle snapshot failures during after or afterEach stages. The main use case for this being tests with several visual test snapshots which currently fail fast upon the first diff failure and subsequent diff failures are not reported